### PR TITLE
flash_service: implement file streaming handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "build-time",
  "if-addrs",
  "log",
+ "mime",
  "nix 0.26.2",
  "serde_json",
  "simple_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "tokio",
+ "tokio-util",
  "tpi_rs",
 ]
 
@@ -803,19 +804,6 @@ checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
-]
-
-[[package]]
-name = "futures-concurrency"
-version = "7.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf49eababd62240534b6e7178bd8b20fac90318ed4295917b0565b6708ed670"
-dependencies = [
- "bitvec",
- "futures-core",
- "pin-project",
- "slab",
- "smallvec",
 ]
 
 [[package]]
@@ -2430,7 +2418,6 @@ dependencies = [
  "crc",
  "evdev",
  "futures",
- "futures-concurrency",
  "gpiod",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,6 @@ dependencies = [
  "futures",
  "if-addrs",
  "log",
- "mime",
  "nix 0.26.2",
  "serde_json",
  "simple_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "build-time",
+ "futures",
  "if-addrs",
  "log",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ tokio = { version = "1.32.0", features = [
     "rt",
     "time",
     "macros",
-    "io-util"
+    "io-util",
+    "net",
 ] }
 tokio-util = "0.7.8"
+futures = "0.3.28"
 
 [profile.release]
 lto = "thin"

--- a/bmcd/Cargo.toml
+++ b/bmcd/Cargo.toml
@@ -16,4 +16,5 @@ tpi_rs = { path = "../tpi_rs" }
 anyhow.workspace = true
 log.workspace = true
 simple_logger.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["net"] }
+mime = "0.3.17"

--- a/bmcd/Cargo.toml
+++ b/bmcd/Cargo.toml
@@ -17,5 +17,4 @@ anyhow.workspace = true
 log.workspace = true
 simple_logger.workspace = true
 tokio = { workspace = true, features = ["net"] }
-mime = "0.3.17"
 futures = "0.3.28"

--- a/bmcd/Cargo.toml
+++ b/bmcd/Cargo.toml
@@ -16,5 +16,6 @@ tpi_rs = { path = "../tpi_rs" }
 anyhow.workspace = true
 log.workspace = true
 simple_logger.workspace = true
-tokio = { workspace = true, features = ["net"] }
-futures = "0.3.28"
+tokio.workspace = true
+tokio-util.workspace = true
+futures.workspace = true

--- a/bmcd/Cargo.toml
+++ b/bmcd/Cargo.toml
@@ -18,3 +18,4 @@ log.workspace = true
 simple_logger.workspace = true
 tokio = { workspace = true, features = ["net"] }
 mime = "0.3.17"
+futures = "0.3.28"

--- a/bmcd/src/flash_service.rs
+++ b/bmcd/src/flash_service.rs
@@ -6,12 +6,12 @@ use tokio::{
     io::{AsyncRead, BufReader},
     sync::mpsc::{channel, error::SendError, Receiver, Sender},
 };
-use tpi_rs::app::flash_application::FlashContext;
 use tpi_rs::{
     app::bmc_application::BmcApplication,
     middleware::{firmware_update::SUPPORTED_DEVICES, NodeId, UsbRoute},
 };
 use tpi_rs::{app::flash_application::flash_node, middleware::firmware_update::FlashStatus};
+use tpi_rs::{app::flash_application::FlashContext, utils::ReceiverReader};
 
 pub struct FlashService {
     status: Option<Sender<Bytes>>,
@@ -39,7 +39,7 @@ impl FlashService {
             filename,
             size,
             node,
-            byte_stream: tokio::fs::File::open("/todo/make/wrapper").await.unwrap(),
+            byte_stream: ReceiverReader::new(receiver),
             bmc: self.bmc.clone(),
             progress_sender,
         };

--- a/bmcd/src/flash_service.rs
+++ b/bmcd/src/flash_service.rs
@@ -46,7 +46,7 @@ impl FlashService {
         &mut self,
         peer: &str,
         filename: String,
-        size: usize,
+        size: u64,
         node: NodeId,
     ) -> Result<FlashDoneFut, FlashError> {
         if let Some(context) = &self.status {

--- a/bmcd/src/flash_service.rs
+++ b/bmcd/src/flash_service.rs
@@ -76,7 +76,12 @@ impl Error for FlashError {}
 
 impl Display for FlashError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        todo!()
+        match self {
+            FlashError::InProgress => write!(f, "flashing operation in progress"),
+            FlashError::UnexpectedCommand => write!(f, "did not expect that command"),
+            FlashError::Aborted => write!(f, "flash operation was aborted"),
+            FlashError::MpscError(_) => write!(f, "internal error sending buffers"),
+        }
     }
 }
 

--- a/bmcd/src/flash_service.rs
+++ b/bmcd/src/flash_service.rs
@@ -1,0 +1,108 @@
+#![allow(dead_code, unused)]
+use crate::into_legacy_response::LegacyResponse;
+use actix_web::{http::StatusCode, web::Bytes};
+use std::{error::Error, fmt::Display, sync::Arc};
+use tokio::{
+    io::{AsyncRead, BufReader},
+    sync::mpsc::{channel, error::SendError, Receiver, Sender},
+};
+use tpi_rs::app::flash_application::FlashContext;
+use tpi_rs::{
+    app::bmc_application::BmcApplication,
+    middleware::{firmware_update::SUPPORTED_DEVICES, NodeId, UsbRoute},
+};
+use tpi_rs::{app::flash_application::flash_node, middleware::firmware_update::FlashStatus};
+
+pub struct FlashService {
+    status: Option<Sender<Bytes>>,
+    bmc: Arc<BmcApplication>,
+}
+
+impl FlashService {
+    pub fn new(bmc: Arc<BmcApplication>) -> Self {
+        Self { status: None, bmc }
+    }
+
+    pub async fn start_transfer(
+        &mut self,
+        filename: String,
+        size: usize,
+        node: NodeId,
+    ) -> Result<(), FlashError> {
+        if self.status.is_some() {
+            return Err(FlashError::InProgress);
+        }
+
+        let (sender, receiver) = channel::<Bytes>(128);
+        let (progress_sender, progress_receiver) = channel(32);
+        let context = FlashContext {
+            filename,
+            size,
+            node,
+            byte_stream: tokio::fs::File::open("/todo/make/wrapper").await.unwrap(),
+            bmc: self.bmc.clone(),
+            progress_sender,
+        };
+
+        /// execute the flashing of the image.
+        tokio::spawn(flash_node(context));
+
+        self.status = Some(sender);
+        Ok(())
+    }
+
+    pub async fn stream_chunk(&mut self, data: Bytes) -> Result<(), FlashError> {
+        if let Some(sender) = &self.status {
+            match sender.send(data).await {
+                Ok(_) => Ok(()),
+                Err(e) if sender.is_closed() => Err(FlashError::Aborted),
+                Err(e) => Err(e.into()),
+            }
+        } else {
+            Err(FlashError::UnexpectedCommand)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum FlashError {
+    InProgress,
+    UnexpectedCommand,
+    Aborted,
+    MpscError(SendError<Bytes>),
+}
+
+impl Error for FlashError {}
+
+impl Display for FlashError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}
+
+impl From<SendError<Bytes>> for FlashError {
+    fn from(value: SendError<Bytes>) -> Self {
+        FlashError::MpscError(value)
+    }
+}
+
+impl From<FlashError> for LegacyResponse {
+    fn from(value: FlashError) -> Self {
+        match value {
+            FlashError::InProgress => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "another flash operation is in progress",
+            )
+                .into(),
+            FlashError::UnexpectedCommand => {
+                (StatusCode::BAD_REQUEST, "did not expect given request").into()
+            }
+            FlashError::MpscError(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into(),
+            FlashError::Aborted => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Flashing process aborted",
+            )
+                .into(),
+        }
+    }
+}

--- a/bmcd/src/into_legacy_response.rs
+++ b/bmcd/src/into_legacy_response.rs
@@ -82,11 +82,11 @@ impl Display for LegacyResponse {
         match self {
             LegacyResponse::Success(s) => write!(
                 f,
-                "success: {}",
+                " {}",
                 s.as_ref().map(|json| json.to_string()).unwrap_or_default()
             ),
-            LegacyResponse::Error(code, msg) => write!(f, "{}:{}", code, msg),
-            LegacyResponse::ErrorOwned(code, msg) => write!(f, "{}:{}", code, msg),
+            LegacyResponse::Error(_, msg) => write!(f, "{}", msg),
+            LegacyResponse::ErrorOwned(_, msg) => write!(f, "{}", msg),
         }
     }
 }

--- a/bmcd/src/into_legacy_response.rs
+++ b/bmcd/src/into_legacy_response.rs
@@ -82,7 +82,7 @@ impl Display for LegacyResponse {
         match self {
             LegacyResponse::Success(s) => write!(
                 f,
-                " {}",
+                "{}",
                 s.as_ref().map(|json| json.to_string()).unwrap_or_default()
             ),
             LegacyResponse::Error(_, msg) => write!(f, "{}", msg),

--- a/bmcd/src/legacy.rs
+++ b/bmcd/src/legacy.rs
@@ -29,16 +29,9 @@ pub fn config(cfg: &mut web::ServiceConfig) {
 }
 
 fn flash_guard(context: &GuardContext<'_>) -> bool {
-    let is_set = context
-        .head()
-        .uri
-        .query()
-        .is_some_and(|q| q.contains("opt=set"));
-    let is_type = context
-        .head()
-        .uri
-        .query()
-        .is_some_and(|q| q.contains("type=flash"));
+    let query = context.head().uri.query();
+    let is_set = query.map(|q| q.contains("opt=set")).unwrap_or(false);
+    let is_type = query.map(|q| q.contains("type=flash")).unwrap_or(false);
     is_set && is_type
 }
 
@@ -351,7 +344,7 @@ async fn handle_flash_request(
         "Invalid `length` query parameter",
     ))?;
 
-    let size = usize::from_str(size)
+    let size = u64::from_str(size)
         .map_err(|_| LegacyResponse::bad_request("`lenght` parameter not a number"))?;
 
     let peer: String = request

--- a/bmcd/src/main.rs
+++ b/bmcd/src/main.rs
@@ -1,8 +1,11 @@
+use crate::flash_service::FlashService;
 use actix_files::Files;
 use actix_web::{middleware, web::Data, App, HttpServer};
 use log::LevelFilter;
 use std::ops::Deref;
+use tokio::sync::Mutex;
 use tpi_rs::app::{bmc_application::BmcApplication, event_application::run_event_listener};
+mod flash_service;
 mod into_legacy_response;
 mod legacy;
 
@@ -17,6 +20,7 @@ async fn main() -> anyhow::Result<()> {
         App::new()
             // Shared state: BmcApplication instance
             .app_data(bmc.clone())
+            .app_data(Mutex::new(FlashService::new(bmc.deref().clone())))
             // Legacy API
             .configure(legacy::config)
             // Enable logger

--- a/bmcd/src/main.rs
+++ b/bmcd/src/main.rs
@@ -16,11 +16,13 @@ async fn main() -> anyhow::Result<()> {
     let bmc = Data::new(BmcApplication::new().await?);
     run_event_listener(bmc.deref().clone())?;
 
+    let flash_service = Data::new(Mutex::new(FlashService::new(bmc.deref().clone())));
+
     HttpServer::new(move || {
         App::new()
             // Shared state: BmcApplication instance
             .app_data(bmc.clone())
-            .app_data(Mutex::new(FlashService::new(bmc.deref().clone())))
+            .app_data(flash_service.clone())
             // Legacy API
             .configure(legacy::config)
             // Enable logger

--- a/tpi_rs/Cargo.toml
+++ b/tpi_rs/Cargo.toml
@@ -12,7 +12,6 @@ bincode = "1.3.3"
 bytes = "1.4.0"
 crc = "3.0.1"
 evdev = { version = "0.12.1", features = ["tokio"] }
-futures = "0.*"
 gpiod = { version = "0.2.3", default-features = false }
 once_cell = "1.18.0"
 rockfile = { version = "0.1.0"}
@@ -24,11 +23,10 @@ sqlx = { version = "0.7.1", features = [
     "runtime-tokio-rustls",
     "sqlite"
 ] }
-futures-concurrency = "7.4.1"
 
 anyhow.workspace = true
 log.workspace = true
 simple_logger.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-
+futures.workspace = true

--- a/tpi_rs/src/c_interface.rs
+++ b/tpi_rs/src/c_interface.rs
@@ -13,6 +13,7 @@ use tokio::join;
 use tokio::sync::mpsc::channel;
 use tokio::sync::mpsc::Receiver;
 use tokio::{runtime::Runtime, sync::Mutex};
+use tokio_util::sync::CancellationToken;
 
 use crate::app::bmc_application::{BmcApplication, UsbConfig};
 use crate::app::event_application::run_event_listener;
@@ -229,6 +230,7 @@ pub unsafe extern "C" fn tpi_flash_node(node: c_int, image_path: *const c_char) 
             byte_stream: img_file,
             bmc: bmc.clone(),
             progress_sender: sender,
+            cancel: CancellationToken::new(),
         };
 
         let handle = tokio::spawn(flash_node(context));

--- a/tpi_rs/src/c_interface.rs
+++ b/tpi_rs/src/c_interface.rs
@@ -225,7 +225,7 @@ pub unsafe extern "C" fn tpi_flash_node(node: c_int, image_path: *const c_char) 
                 .unwrap()
                 .to_string_lossy()
                 .to_string(),
-            size: img_len as usize,
+            size: img_len,
             node: node_id,
             byte_stream: img_file,
             bmc: bmc.clone(),

--- a/tpi_rs/src/utils/io.rs
+++ b/tpi_rs/src/utils/io.rs
@@ -1,0 +1,146 @@
+use bytes::BufMut;
+use std::{io, ops::Deref, task::Poll};
+use tokio::{
+    io::{AsyncRead, ReadBuf},
+    sync::mpsc::Receiver,
+};
+
+/// This struct wraps a [tokio::sync::mpsc::Receiver] and transforms that
+/// exposes a [AsyncRead] interface.
+pub struct ReceiverReader<T>
+where
+    T: Deref<Target = [u8]>,
+{
+    receiver: Receiver<T>,
+    buffer: Vec<u8>,
+}
+
+impl<T> ReceiverReader<T>
+where
+    T: Deref<Target = [u8]>,
+{
+    pub fn new(receiver: Receiver<T>) -> Self {
+        Self {
+            receiver,
+            buffer: Vec::new(),
+        }
+    }
+
+    pub fn push_to_buffer(&mut self, data: &[u8]) {
+        self.buffer.extend_from_slice(data);
+    }
+
+    pub fn take_buffered_bytes(&mut self, read_buf: &mut ReadBuf<'_>) -> bool {
+        let len = self.buffer.len().min(read_buf.remaining());
+        if len > 0 {
+            let data: Vec<u8> = self.buffer.drain(..len).collect();
+            read_buf.put_slice(&data);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<T> AsyncRead for ReceiverReader<T>
+where
+    T: Deref<Target = [u8]>,
+{
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        let mut read_bytes = this.take_buffered_bytes(buf);
+
+        while buf.has_remaining_mut() {
+            match this.receiver.poll_recv(cx) {
+                Poll::Ready(Some(c)) => {
+                    let bytes = c.deref();
+                    let len = bytes.len().min(buf.remaining());
+                    buf.put_slice(&bytes[..len]);
+                    read_bytes = true;
+
+                    if len < bytes.len() {
+                        this.push_to_buffer(&bytes[len..]);
+                    }
+                }
+                Poll::Ready(None) => {
+                    if !read_bytes {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::BrokenPipe,
+                            "channel closed",
+                        )));
+                    } else {
+                        return Poll::Ready(Ok(()));
+                    }
+                }
+                Poll::Pending => return Poll::Pending,
+            };
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tokio::{io::AsyncReadExt, sync::mpsc::channel};
+
+    #[tokio::test]
+    async fn receive_once_and_drain_buffer_test() {
+        let (sender, receiver) = channel::<Vec<u8>>(2);
+        let mut rr = ReceiverReader::new(receiver);
+        sender.send(vec![1, 2]).await.unwrap();
+        drop(sender);
+
+        let mut buffer = [0u8; 5];
+        rr.read(&mut buffer[0..1]).await.unwrap();
+        assert_eq!(buffer[0], 1);
+        rr.read(&mut buffer[0..1]).await.unwrap();
+        assert_eq!(buffer[0], 2);
+        assert!(rr.read(&mut buffer[0..1]).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn drain_buffer_and_new_read_available_test() {
+        let (sender, receiver) = channel::<Vec<u8>>(2);
+        let mut rr = ReceiverReader::new(receiver);
+        sender.send(vec![1, 2]).await.unwrap();
+
+        let mut buffer = [0u8; 5];
+        rr.read(&mut buffer[0..1]).await.unwrap();
+        assert_eq!(buffer[0], 1);
+        rr.read(&mut buffer[0..1]).await.unwrap();
+        assert_eq!(buffer[0], 2);
+        sender.send(vec![8, 9]).await.unwrap();
+        rr.read(&mut buffer[0..2]).await.unwrap();
+        assert_eq!(vec![8, 9], buffer[0..2]);
+    }
+
+    #[tokio::test]
+    async fn exhaust_reader_return_result() {
+        let (sender, receiver) = channel::<Vec<u8>>(2);
+        let result = tokio::spawn(async {
+            let mut rr = ReceiverReader::new(receiver);
+            let mut buffer = [0u8; 5];
+            rr.read(&mut buffer).await.unwrap();
+            assert_eq!(vec![1, 2, 3, 4, 5], buffer);
+            rr
+        });
+
+        sender.send(vec![1, 2]).await.unwrap();
+        sender.send(vec![3, 4, 5, 6, 7]).await.unwrap();
+        let mut rr = result.await.unwrap();
+        drop(sender);
+
+        let mut buffer = [0u8; 4];
+        let res = rr.read(&mut buffer).await.unwrap();
+        // we have exhaust the channel unable to complete the whole 4 bytes
+        // read request. return the last available bytes
+        assert_eq!(vec![6, 7], buffer[0..2]);
+        assert_eq!(res, 2);
+    }
+}

--- a/tpi_rs/src/utils/mod.rs
+++ b/tpi_rs/src/utils/mod.rs
@@ -1,5 +1,20 @@
 mod event_listener;
+use std::fmt::Display;
+
 #[doc(inline)]
 pub use event_listener::*;
 mod io;
 pub use io::*;
+use tokio::sync::mpsc::Receiver;
+
+// for now we print the status updates to console. In the future we would like to pass
+// this back to the clients.
+pub fn logging_sink<T: Display + Send + 'static>(
+    mut receiver: Receiver<T>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(msg) = receiver.recv().await {
+            log::info!("{}", msg);
+        }
+    })
+}

--- a/tpi_rs/src/utils/mod.rs
+++ b/tpi_rs/src/utils/mod.rs
@@ -1,3 +1,5 @@
 mod event_listener;
 #[doc(inline)]
 pub use event_listener::*;
+mod io;
+pub use io::*;


### PR DESCRIPTION
Added a handler in the 'bmcd' that:
* receives a firmware image over the http API endpoint
* buffers these image chunks
* async write chunks to a given node