### PR TITLE
enable tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "ahash",
  "base64",
@@ -88,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.32",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -143,6 +144,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-tls"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72616e7fbec0aa99c6f3164677fa48ff5a60036d0799c98cab894a44f3e0efc3"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "impl-more",
+ "openssl",
+ "pin-project-lite",
+ "rustls",
+ "rustls-webpki",
+ "tokio",
+ "tokio-openssl",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +187,7 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "actix-web-codegen",
  "ahash",
@@ -201,7 +224,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -412,7 +435,10 @@ dependencies = [
  "if-addrs",
  "log",
  "nix 0.26.4",
+ "openssl",
+ "serde",
  "serde_json",
+ "serde_yaml",
  "simple_logger",
  "tokio",
  "tokio-util",
@@ -450,14 +476,14 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytes"
@@ -718,6 +744,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,7 +835,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -980,6 +1021,12 @@ dependencies = [
  "libc",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "impl-more"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
 
 [[package]]
 name = "indexmap"
@@ -1267,6 +1314,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "openssl"
+version = "0.10.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -1474,6 +1559,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rockfile"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1634,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustpiboot"
 version = "0.2.0"
 source = "git+https://github.com/ruslashev/rustpiboot.git?rev=89e6497#89e6497b6d96c8a8195fa6460ab45a9fee170732"
@@ -1553,6 +1675,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -1577,14 +1709,14 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -1601,6 +1733,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+dependencies = [
+ "indexmap 2.0.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1661,6 +1806,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1721,7 +1872,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1796,7 +1947,19 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
+dependencies = [
+ "futures-util",
+ "openssl",
+ "openssl-sys",
+ "tokio",
 ]
 
 [[package]]
@@ -1912,6 +2075,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,7 +2142,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.33",
  "wasm-bindgen-shared",
 ]
 
@@ -1989,7 +2164,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.33",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1999,6 +2174,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1.32.0", features = [
 ] }
 tokio-util = "0.7.8"
 futures = "0.3.28"
+serde = { version = "1.0.188", features = ["derive"] }
 
 [profile.release]
 lto = "thin"

--- a/bmcd/Cargo.toml
+++ b/bmcd/Cargo.toml
@@ -6,13 +6,15 @@ license.workspace = true
 
 [dependencies]
 actix-files = "0.6.2"
-actix-web = "4.4.0"
+actix-web = { version = "4.4.0", features = ["openssl"] }
 build-time = "0.1.3"
 if-addrs = "0.10.1"
 nix = "0.26.4"
 serde_json = "1.0.106"
+serde_yaml = "0.9.25"
 tpi_rs = { path = "../tpi_rs" }
-clap = "4.4.2"
+clap = { version = "4.4.2", features = ["cargo"] }
+openssl = "0.10.57"
 
 anyhow.workspace = true
 log.workspace = true
@@ -20,3 +22,4 @@ simple_logger.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 futures.workspace = true
+serde.workspace = true

--- a/bmcd/src/config.rs
+++ b/bmcd/src/config.rs
@@ -1,0 +1,23 @@
+use serde::Deserialize;
+use std::fs::OpenOptions;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub tls: Tls,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Tls {
+    pub private_key: PathBuf,
+    pub certificate: PathBuf,
+}
+
+impl TryFrom<PathBuf> for Config {
+    type Error = anyhow::Error;
+
+    fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
+        let file = OpenOptions::new().read(true).open(value)?;
+        Ok(serde_yaml::from_reader(file)?)
+    }
+}

--- a/bmcd/src/main.rs
+++ b/bmcd/src/main.rs
@@ -1,25 +1,45 @@
 use crate::flash_service::FlashService;
 use actix_files::Files;
-use actix_web::{http::KeepAlive, middleware, web::Data, App, HttpServer};
+use actix_web::{
+    http::{self, KeepAlive},
+    middleware, web,
+    web::Data,
+    App, HttpRequest, HttpResponse, HttpServer,
+};
+use anyhow::Context;
+use clap::{command, value_parser, Arg};
 use log::LevelFilter;
-use std::sync::Arc;
+use openssl::ssl::SslAcceptorBuilder;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tokio::sync::Mutex;
 use tpi_rs::app::{bmc_application::BmcApplication, event_application::run_event_listener};
+pub mod config;
 mod flash_service;
 mod into_legacy_response;
 mod legacy;
+use crate::config::Config;
+use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
+
+const HTTPS_PORT: u16 = 443;
+const HTTP_PORT: u16 = 80;
 
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
     init_logger();
 
+    let config = Config::try_from(config_path()).context("Error parsing config file")?;
+    let tls = load_tls_configuration(&config.tls.private_key, &config.tls.certificate)?;
+    let tls6 = load_tls_configuration(&config.tls.private_key, &config.tls.certificate)?;
+
     let bmc = Arc::new(BmcApplication::new().await?);
     run_event_listener(bmc.clone())?;
-
     let flash_service = Data::new(Mutex::new(FlashService::new(bmc.clone())));
     let bmc = Data::from(bmc);
 
-    HttpServer::new(move || {
+    let run_server = HttpServer::new(move || {
         App::new()
             // Shared state: BmcApplication instance
             .app_data(bmc.clone())
@@ -31,15 +51,29 @@ async fn main() -> anyhow::Result<()> {
             // Serve a static tree of files of the web UI. Must be the last item.
             .service(Files::new("/", "/mnt/var/www/").index_file("index.html"))
     })
-    .bind(("0.0.0.0", 80))?
-    .bind(("::1", 80))?
+    .bind_openssl(("0.0.0.0", HTTPS_PORT), tls)?
+    .bind_openssl(("::1", HTTPS_PORT), tls6)?
     .keep_alive(KeepAlive::Os)
     .workers(2)
-    .run()
-    .await?;
+    .run();
 
+    // redirect requests to 'HTTPS'
+    let redirect_server = HttpServer::new(move || App::new().route("/", web::get().to(redirect)))
+        .bind(("0.0.0.0", HTTP_PORT))?
+        .run();
+
+    tokio::try_join!(run_server, redirect_server)?;
     log::info!("exiting {}", env!("CARGO_PKG_NAME"));
     Ok(())
+}
+
+async fn redirect(request: HttpRequest) -> HttpResponse {
+    let host = request.connection_info().host().to_string();
+    let path = request.uri().to_string();
+    let redirect_url = format!("https://{}{}", host, path);
+    HttpResponse::PermanentRedirect()
+        .append_header((http::header::LOCATION, redirect_url))
+        .finish()
 }
 
 fn init_logger() {
@@ -59,4 +93,28 @@ fn init_logger() {
         .expect("failed to initialize logger");
 
     log::info!("Turing Pi 2 BMC Daemon v{}", env!("CARGO_PKG_VERSION"));
+}
+
+fn config_path() -> PathBuf {
+    command!()
+        .arg(
+            Arg::new("config")
+                .long("config")
+                .value_parser(value_parser!(PathBuf))
+                .required(true),
+        )
+        .get_matches()
+        .get_one::<PathBuf>("config")
+        .expect("`config` argument required")
+        .into()
+}
+
+fn load_tls_configuration<P: AsRef<Path>>(
+    private_key: P,
+    certificate: P,
+) -> anyhow::Result<SslAcceptorBuilder> {
+    let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls())?;
+    builder.set_private_key_file(private_key.as_ref(), SslFiletype::PEM)?;
+    builder.set_certificate_chain_file(certificate.as_ref())?;
+    Ok(builder)
 }


### PR DESCRIPTION
TLS is added and enforced. the bmcd requires a `--certificate` and `--private-key` argument in order to run.

A server is binded onto the old `80` port, that will redirect traffic to 443