### PR TITLE
bmcd: listen on IPv6 & increase KeepAlive

### DIFF
--- a/bmcd/src/main.rs
+++ b/bmcd/src/main.rs
@@ -1,6 +1,6 @@
 use crate::flash_service::FlashService;
 use actix_files::Files;
-use actix_web::{middleware, web::Data, App, HttpServer};
+use actix_web::{http::KeepAlive, middleware, web::Data, App, HttpServer};
 use log::LevelFilter;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -32,6 +32,8 @@ async fn main() -> anyhow::Result<()> {
             .service(Files::new("/", "/mnt/var/www/").index_file("index.html"))
     })
     .bind(("0.0.0.0", 80))?
+    .bind(("::1", 80))?
+    .keep_alive(KeepAlive::Os)
     .workers(2)
     .run()
     .await?;


### PR DESCRIPTION
Prevent the TCP connection from closing during a flashing process. When the receive buffer is full, byte chunk requests will be blocked until new space becomes available. This caused connection resets, resulting in an abort of the flashing process. This happens, for example, during the configuration phase of the node which typically takes longer as 5 sec. default keep-alive for HTTP1.1 was 5 sec. This CL align sets the keep-alive timeout to the value of the underlaying OS.