### PR TITLE
persistency: maturing component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "simple_logger",
  "tokio",
@@ -575,6 +576,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-targets 0.48.5",
 ]
 
@@ -708,10 +710,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "derive_more"
@@ -1029,6 +1069,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1137,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1176,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1134,6 +1187,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1883,6 +1937,35 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/bmcd/Cargo.toml
+++ b/bmcd/Cargo.toml
@@ -26,3 +26,4 @@ tokio.workspace = true
 tokio-util.workspace = true
 futures.workspace = true
 serde.workspace = true
+serde_with = "3.3.0"

--- a/bmcd/src/config.rs
+++ b/bmcd/src/config.rs
@@ -12,12 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use serde::Deserialize;
+use serde_with::serde_as;
+use serde_with::DurationSeconds;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
+use std::time::Duration;
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct Config {
     pub tls: Tls,
+    #[serde_as(as = "Option<DurationSeconds<u64>>")]
+    pub write_timeout: Option<Duration>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/default_config.yaml
+++ b/default_config.yaml
@@ -1,0 +1,10 @@
+---
+tls:
+  certificate: /etc/ssl/certs/bmcd_cert.pem
+  private_key: /etc/ssl/certs/bmcd_key.pem
+# The bmcd contains a write mechanism that writes its internal key/value store
+# back to the file-system. This happens on a timeout started from the last
+# write. Commenting out `write_timeout` disables the write on timeout. In this
+# case the store will only be synced back to file-system on a graceful shutdown.
+# Value is in seconds.
+write_timeout: 300

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,7 @@ allow = [
     "MIT",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
     "OpenSSL",

--- a/tpi_rs/src/app/bmc_application.rs
+++ b/tpi_rs/src/app/bmc_application.rs
@@ -66,12 +66,13 @@ pub struct BmcApplication {
 }
 
 impl BmcApplication {
-    pub async fn new() -> anyhow::Result<Self> {
+    pub async fn new(database_write_timeout: Option<Duration>) -> anyhow::Result<Self> {
         let pin_controller = PinController::new().context("pin_controller")?;
         let power_controller = PowerController::new().context("power_controller")?;
         let app_db = PersistencyBuilder::default()
             .register_key(ACTIVATED_NODES_KEY, &0u8)
             .register_key(USB_CONFIG, &UsbConfig::UsbA(NodeId::Node1))
+            .write_timeout(database_write_timeout)
             .build()
             .await?;
         let serial = SerialConnections::new()?;

--- a/tpi_rs/src/c_interface.rs
+++ b/tpi_rs/src/c_interface.rs
@@ -60,7 +60,7 @@ pub extern "C" fn tpi_initialize() {
         log::info!("{} v{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
 
         let bmc = Arc::new(
-            BmcApplication::new()
+            BmcApplication::new(None)
                 .await
                 .expect("unable to initialize bmc app"),
         );

--- a/tpi_rs/src/utils/ring_buf.rs
+++ b/tpi_rs/src/utils/ring_buf.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_simple() {
-        let mut b = RingBuffer::<5>::new();
+        let mut b = RingBuffer::<5>::default();
         let empty: Vec<u8> = vec![];
         assert_eq!(b.read(), empty);
         b.write(&[1, 2, 3]);
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_exact_size() {
-        let mut b = RingBuffer::<3>::new();
+        let mut b = RingBuffer::<3>::default();
         b.write(&[1, 2, 3]);
         assert_eq!(b.read(), [1, 2, 3]);
         b.write(&[4, 5, 6, 7]);
@@ -88,14 +88,14 @@ mod tests {
 
     #[test]
     fn test_overflow_simple() {
-        let mut b = RingBuffer::<5>::new();
+        let mut b = RingBuffer::<5>::default();
         b.write(&[1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(b.read(), [3, 4, 5, 6, 7]);
     }
 
     #[test]
     fn test_overflow() {
-        let mut b = RingBuffer::<5>::new();
+        let mut b = RingBuffer::<5>::default();
         b.write(&[1, 2, 3]);
         b.write(&[4, 5, 6, 7]);
         assert_eq!(b.read(), [3, 4, 5, 6, 7]);
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_overflow_exact() {
-        let mut b = RingBuffer::<5>::new();
+        let mut b = RingBuffer::<5>::default();
         b.write(&[1, 2]);
         b.write(&[3, 4, 5, 6, 7]);
         assert_eq!(b.read(), [3, 4, 5, 6, 7]);
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_overflow_wrap() {
-        let mut b = RingBuffer::<5>::new();
+        let mut b = RingBuffer::<5>::default();
         b.write(&[1, 2]);
         b.write(&[3, 4, 5, 6, 7, 8, 9]);
         assert_eq!(b.read(), [5, 6, 7, 8, 9]);


### PR DESCRIPTION
* Implemented a fallback mechanism when the database binary is corrupted. In this case the binary will be omitted and overwritten with an default store on successive write-backs of the store to disk
* Improved fatal error messages on erroneous `.get()` and `.set()` calls.
* Created a new config file item: `write_timeout`. Controls the write timeout of the persistency. More information inside `default_config.yaml`