### PR TITLE
firmware_update: rockusb_fwudate

### DIFF
--- a/src/api/legacy.rs
+++ b/src/api/legacy.rs
@@ -18,7 +18,6 @@ use crate::api::streaming_data_service::StreamingDataService;
 use crate::app::bmc_application::{BmcApplication, Encoding, UsbConfig};
 use crate::app::transfer_action::{TransferType, UpgradeAction, UpgradeType};
 use crate::hal::{NodeId, UsbMode, UsbRoute};
-use crate::utils::logging_sink;
 use actix_multipart::Multipart;
 use actix_web::guard::{fn_guard, GuardContext};
 use actix_web::http::StatusCode;
@@ -29,7 +28,6 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::str::FromStr;
 use tokio::io::AsyncBufReadExt;
-use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
 type Query = web::Query<std::collections::HashMap<String, String>>;
 
@@ -160,10 +158,7 @@ fn get_node_info(_bmc: &BmcApplication) -> impl Into<LegacyResponse> {
 
 async fn set_node_to_msd(bmc: &BmcApplication, query: Query) -> LegacyResult<()> {
     let node = get_node_param(&query)?;
-
-    let (tx, rx) = mpsc::channel(64);
-    logging_sink(rx);
-    bmc.set_node_in_msd(node, UsbRoute::Bmc, tx)
+    bmc.set_node_in_msd(node, UsbRoute::Bmc)
         .await
         .map(|_| ())
         .map_err(Into::into)

--- a/src/app/bmc_application.rs
+++ b/src/app/bmc_application.rs
@@ -223,7 +223,7 @@ impl BmcApplication {
     pub async fn set_node_in_msd(&self, node: NodeId, router: UsbRoute) -> anyhow::Result<()> {
         // The SUPPORTED_MSD_DEVICES list contains vid_pids of USB drivers we know will load the
         // storage of a node as a MSD device.
-        self.configure_node_for_fwupgrade(node, router, SUPPORTED_DEVICES.keys().into_iter())
+        self.configure_node_for_fwupgrade(node, router, SUPPORTED_DEVICES.keys())
             .await
             .map(|_| ())
     }
@@ -258,6 +258,7 @@ impl BmcApplication {
 
         tokio::time::sleep(Duration::from_secs(1)).await;
 
+        self.clear_usb_boot()?;
         log::info!("Checking for presence of a USB device...");
 
         let matches = usbboot::get_usb_devices(any_of)?;

--- a/src/firmware_update/mod.rs
+++ b/src/firmware_update/mod.rs
@@ -15,137 +15,70 @@ mod rockusb_fwudate;
 use self::rockusb_fwudate::new_rockusb_transport;
 mod rpi_fwupdate;
 use rpi_fwupdate::new_rpi_transport;
-use serde::Serialize;
+use thiserror::Error;
 pub mod transport;
 use self::transport::FwUpdateTransport;
 use futures::future::BoxFuture;
 use once_cell::sync::Lazy;
 use rusb::GlobalContext;
-use std::{
-    collections::HashMap,
-    fmt::{self, Display},
-};
-use tokio::sync::mpsc::Sender;
-
-#[allow(clippy::vec_init_then_push)]
-pub static SUPPORTED_MSD_DEVICES: Lazy<Vec<(u16, u16)>> = Lazy::new(|| {
-    let mut supported = Vec::<(u16, u16)>::new();
-    supported.push(rpi_fwupdate::VID_PID);
-    supported
-});
+use std::collections::HashMap;
 
 pub static SUPPORTED_DEVICES: Lazy<HashMap<(u16, u16), FactoryItemCreator>> = Lazy::new(|| {
     let mut creators = HashMap::<(u16, u16), FactoryItemCreator>::new();
     creators.insert(
         rpi_fwupdate::VID_PID,
-        Box::new(|_, logging| {
-            Box::pin(async move { new_rpi_transport(&logging).await.map(Into::into) })
-        }),
+        Box::new(|_| Box::pin(async move { new_rpi_transport().await.map(Into::into) })),
     );
 
     creators.insert(
         rockusb_fwudate::RK3588_VID_PID,
-        Box::new(|device, logging| {
+        Box::new(|device| {
             let clone = device.clone();
-            Box::pin(async move { new_rockusb_transport(clone, &logging).await.map(Into::into) })
+            Box::pin(async move { new_rockusb_transport(clone).await.map(Into::into) })
         }),
     );
 
     creators
 });
 
-pub type FactoryItem = BoxFuture<'static, Result<Box<dyn FwUpdateTransport>, FlashingError>>;
+pub type FactoryItem = BoxFuture<'static, Result<Box<dyn FwUpdateTransport>, FwUpdateError>>;
 pub type FactoryItemCreator =
-    Box<dyn Fn(&rusb::Device<GlobalContext>, Sender<FlashProgress>) -> FactoryItem + Send + Sync>;
+    Box<dyn Fn(&rusb::Device<GlobalContext>) -> FactoryItem + Send + Sync>;
 
 pub fn fw_update_transport(
     device: &rusb::Device<GlobalContext>,
-    logging: Sender<FlashProgress>,
-) -> anyhow::Result<FactoryItem> {
+) -> Result<FactoryItem, FwUpdateError> {
     let descriptor = device.device_descriptor()?;
     let vid_pid = (descriptor.vendor_id(), descriptor.product_id());
 
     SUPPORTED_DEVICES
         .get(&vid_pid)
-        .map(|creator| creator(device, logging))
-        .ok_or(anyhow::anyhow!("no driver available for {:?}", device))
+        .map(|creator| creator(device))
+        .ok_or(FwUpdateError::NoDriver(device.clone()))
 }
 
-#[derive(Serialize, Debug, Clone, Copy)]
-pub enum FlashingError {
-    DeviceNotFound,
-    GpioError,
-    UsbError,
-    IoError,
+#[derive(Error, Debug)]
+pub enum FwUpdateError {
+    #[error("No supported devices found")]
+    NoDevices,
+    #[error("No MSD USB devices found")]
+    NoMsdDevices,
+    #[error("Several supported devices found: found {0:?}, expected 1")]
+    MultipleDevicesFound(usize),
+    #[error("USB")]
+    RusbError(#[from] rusb::Error),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error("Error loading as USB MSD: {0}")]
+    InternalError(String),
+    #[error("integrity check of written image failed")]
     ChecksumMismatch,
+    #[error("no firmware update driver available for {0:?}")]
+    NoDriver(rusb::Device<GlobalContext>),
 }
 
-impl fmt::Display for FlashingError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FlashingError::DeviceNotFound => write!(f, "Device not found"),
-            FlashingError::GpioError => write!(f, "Error toggling GPIO lines"),
-            FlashingError::UsbError => write!(f, "Error enumerating USB devices"),
-            FlashingError::IoError => write!(f, "File IO error"),
-            FlashingError::ChecksumMismatch => {
-                write!(f, "Failed to verify image after writing to the node")
-            }
-        }
-    }
-}
-
-impl std::error::Error for FlashingError {}
-
-pub trait FlashingErrorExt<T, E: Display> {
-    fn map_err_into_logged_usb(self, logging: &Sender<FlashProgress>) -> Result<T, FlashingError>;
-    fn map_err_into_logged_io(self, logging: &Sender<FlashProgress>) -> Result<T, FlashingError>;
-}
-
-impl<T, E: Display> FlashingErrorExt<T, E> for Result<T, E> {
-    fn map_err_into_logged_usb(self, logging: &Sender<FlashProgress>) -> Result<T, FlashingError> {
-        self.map_err(|e| {
-            logging
-                .try_send(FlashProgress {
-                    status: FlashStatus::Error(FlashingError::UsbError),
-                    message: format!("{}", e),
-                })
-                .expect("logging channel to be open");
-            FlashingError::UsbError
-        })
-    }
-    fn map_err_into_logged_io(self, logging: &Sender<FlashProgress>) -> Result<T, FlashingError> {
-        self.map_err(|e| {
-            logging
-                .try_send(FlashProgress {
-                    status: FlashStatus::Error(FlashingError::IoError),
-                    message: format!("{}", e),
-                })
-                .expect("logging channel to be open");
-            FlashingError::IoError
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum FlashStatus {
-    Idle,
-    Setup,
-    Progress {
-        read_percent: usize,
-        est_minutes: u64,
-        est_seconds: u64,
-    },
-    Error(FlashingError),
-}
-
-#[derive(Debug, Clone)]
-pub struct FlashProgress {
-    pub status: FlashStatus,
-    pub message: String,
-}
-
-impl Display for FlashProgress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
+impl FwUpdateError {
+    pub fn internal_error<E: ToString>(error: E) -> FwUpdateError {
+        FwUpdateError::InternalError(error.to_string())
     }
 }

--- a/src/firmware_update/rpi_fwupdate.rs
+++ b/src/firmware_update/rpi_fwupdate.rs
@@ -11,125 +11,35 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::{path::PathBuf, time::Duration};
-use tokio::{fs::File, sync::mpsc::Sender, time::sleep};
-
-use super::{FlashProgress, FlashStatus, FlashingError};
+use crate::{firmware_update::FwUpdateError, hal::usbboot::get_device_path};
+use std::time::Duration;
+use tokio::{fs::File, time::sleep};
 
 pub const VID_PID: (u16, u16) = (0x0a5c, 0x2711);
-pub async fn new_rpi_transport(logging: &Sender<FlashProgress>) -> Result<File, FlashingError> {
+pub async fn new_rpi_transport() -> Result<File, FwUpdateError> {
     let options = rustpiboot::Options {
         delay: 500 * 1000,
         ..Default::default()
     };
 
-    let _ = logging
-        .send(FlashProgress {
-            status: FlashStatus::Setup,
-            message: "Rebooting as a USB mass storage device...".to_string(),
-        })
-        .await;
+    log::info!("Rebooting as a USB mass storage device...");
 
     rustpiboot::boot(options).map_err(|err| {
-        logging
-            .try_send(FlashProgress {
-                status: FlashStatus::Error(FlashingError::IoError),
-                message: format!("Failed to reboot {:?} as USB MSD: {:?}", VID_PID, err),
-            })
-            .unwrap();
-        FlashingError::UsbError
+        FwUpdateError::internal_error(format!(
+            "Failed to reboot {:?} as USB MSD: {:?}",
+            VID_PID, err
+        ))
     })?;
 
     sleep(Duration::from_secs(3)).await;
 
-    let _ = logging
-        .send(FlashProgress {
-            status: FlashStatus::Setup,
-            message: "Checking for presence of a device file...".to_string(),
-        })
-        .await;
-
+    log::info!("Checking for presence of a device file...");
     let device_path = get_device_path(["RPi-MSD-"]).await?;
     let msd_device = tokio::fs::OpenOptions::new()
         .write(true)
         .read(true)
         .open(&device_path)
-        .await
-        .map_err(|e| {
-            logging
-                .try_send(FlashProgress {
-                    status: FlashStatus::Error(FlashingError::DeviceNotFound),
-                    message: format!("cannot open {:?} : {:?}", device_path, e),
-                })
-                .unwrap();
-            FlashingError::DeviceNotFound
-        })?;
+        .await?;
 
     Ok(msd_device)
-}
-
-async fn get_device_path<I: IntoIterator<Item = &'static str>>(
-    allowed_vendors: I,
-) -> Result<PathBuf, FlashingError> {
-    let mut contents = tokio::fs::read_dir("/dev/disk/by-id")
-        .await
-        .map_err(|err| {
-            log::error!("Failed to list devices: {}", err);
-            FlashingError::IoError
-        })?;
-
-    let target_prefixes = allowed_vendors
-        .into_iter()
-        .map(|vendor| format!("usb-{}_", vendor))
-        .collect::<Vec<String>>();
-
-    let mut matching_devices = vec![];
-
-    while let Some(entry) = contents.next_entry().await.map_err(|err| {
-        log::warn!("Intermittent IO error while listing devices: {}", err);
-        FlashingError::IoError
-    })? {
-        let Ok(file_name) = entry.file_name().into_string() else {
-            continue;
-        };
-
-        for prefix in &target_prefixes {
-            if file_name.starts_with(prefix) {
-                matching_devices.push(file_name.clone());
-            }
-        }
-    }
-
-    // Exclude partitions, i.e. turns [ "x-part2", "x-part1", "x", "y-part2", "y-part1", "y" ]
-    // into ["x", "y"].
-    let unique_root_devices = matching_devices
-        .iter()
-        .filter(|this| {
-            !matching_devices
-                .iter()
-                .any(|other| this.starts_with(other) && *this != other)
-        })
-        .collect::<Vec<&String>>();
-
-    let symlink = match unique_root_devices[..] {
-        [] => {
-            log::error!("No supported devices found");
-            return Err(FlashingError::DeviceNotFound);
-        }
-        [device] => device.clone(),
-        _ => {
-            log::error!(
-                "Several supported devices found: found {}, expected 1",
-                unique_root_devices.len()
-            );
-            return Err(FlashingError::GpioError);
-        }
-    };
-
-    tokio::fs::canonicalize(format!("/dev/disk/by-id/{}", symlink))
-        .await
-        .map_err(|err| {
-            log::error!("Failed to read link: {}", err);
-            FlashingError::IoError
-        })
 }

--- a/src/firmware_update/transport.rs
+++ b/src/firmware_update/transport.rs
@@ -50,6 +50,7 @@ pub struct StdTransportWrapper<T> {
 }
 
 impl<T: StdFwUpdateTransport> StdTransportWrapper<T> {
+    #[allow(unused)]
     pub fn new(object: T) -> Self {
         Self {
             transport: object,

--- a/src/hal/usbboot.rs
+++ b/src/hal/usbboot.rs
@@ -11,19 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::firmware_update::FlashingError;
 use anyhow::{Context, Result};
 use rusb::{Device, GlobalContext, UsbContext};
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
+
+use crate::firmware_update::FwUpdateError;
 
 pub(crate) fn get_usb_devices<'a, I: IntoIterator<Item = &'a (u16, u16)>>(
     filter: I,
-) -> std::result::Result<Vec<Device<GlobalContext>>, FlashingError> {
-    let all_devices = rusb::DeviceList::new().map_err(|err| {
-        log::error!("failed to get USB device list: {}", err);
-        FlashingError::UsbError
-    })?;
-
+) -> std::result::Result<Vec<Device<GlobalContext>>, FwUpdateError> {
+    let all_devices = rusb::DeviceList::new()?;
     let filter = filter.into_iter().collect::<Vec<&'a (u16, u16)>>();
     let devices = all_devices
         .iter()
@@ -34,6 +31,7 @@ pub(crate) fn get_usb_devices<'a, I: IntoIterator<Item = &'a (u16, u16)>>(
         })
         .collect::<Vec<Device<GlobalContext>>>();
 
+    log::debug!("matches:{:?}", devices);
     Ok(devices)
 }
 
@@ -48,16 +46,69 @@ fn map_to_serial<T: UsbContext>(dev: &rusb::Device<T>) -> anyhow::Result<String>
         .context("error reading serial")
 }
 
-pub(crate) fn extract_one_device<T>(devices: &[T]) -> Result<&T, FlashingError> {
+pub(crate) fn extract_one_device<T>(devices: &[T]) -> Result<&T, FwUpdateError> {
     match devices.len() {
         1 => Ok(devices.first().unwrap()),
-        0 => {
-            log::error!("No supported devices found");
-            Err(FlashingError::DeviceNotFound)
-        }
-        n => {
-            log::error!("Several supported devices found: found {}, expected 1", n);
-            Err(FlashingError::GpioError)
+        0 => Err(FwUpdateError::NoDevices),
+        n => Err(FwUpdateError::MultipleDevicesFound(n)),
+    }
+}
+
+pub async fn get_device_path<I: IntoIterator<Item = &'static str>>(
+    allowed_vendors: I,
+) -> Result<PathBuf, FwUpdateError> {
+    let mut contents = tokio::fs::read_dir("/dev/disk/by-id")
+        .await
+        .map_err(|err| {
+            std::io::Error::new(err.kind(), format!("Failed to list devices: {}", err))
+        })?;
+
+    let target_prefixes = allowed_vendors
+        .into_iter()
+        .map(|vendor| format!("usb-{}_", vendor))
+        .collect::<Vec<String>>();
+
+    let mut matching_devices = vec![];
+
+    while let Some(entry) = contents.next_entry().await.map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!("Intermittent IO error while listing devices: {}", err),
+        )
+    })? {
+        let Ok(file_name) = entry.file_name().into_string() else {
+            continue;
+        };
+
+        for prefix in &target_prefixes {
+            if file_name.starts_with(prefix) {
+                matching_devices.push(file_name.clone());
+            }
         }
     }
+
+    // Exclude partitions, i.e. turns [ "x-part2", "x-part1", "x", "y-part2", "y-part1", "y" ]
+    // into ["x", "y"].
+    let unique_root_devices = matching_devices
+        .iter()
+        .filter(|this| {
+            !matching_devices
+                .iter()
+                .any(|other| this.starts_with(other) && *this != other)
+        })
+        .collect::<Vec<&String>>();
+
+    let symlink = match unique_root_devices[..] {
+        [] => {
+            return Err(FwUpdateError::NoMsdDevices);
+        }
+        [device] => device.clone(),
+        _ => {
+            return Err(FwUpdateError::MultipleDevicesFound(
+                unique_root_devices.len(),
+            ));
+        }
+    };
+
+    Ok(tokio::fs::canonicalize(format!("/dev/disk/by-id/{}", symlink)).await?)
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,27 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 mod event_listener;
+mod io;
 pub mod ring_buf;
-
-use std::fmt::Display;
-
 #[doc(inline)]
 pub use event_listener::*;
-mod io;
 pub use io::*;
-use tokio::sync::mpsc::Receiver;
-
-// for now we print the status updates to console. In the future we would like to pass
-// this back to the clients.
-pub fn logging_sink<T: Display + Send + 'static>(
-    mut receiver: Receiver<T>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        while let Some(msg) = receiver.recv().await {
-            log::info!("{}", msg);
-        }
-    })
-}
 
 pub fn string_from_utf16(bytes: &[u8], little_endian: bool) -> String {
     let u16s = bytes.chunks_exact(2).map(|pair| {


### PR DESCRIPTION
* Use the "new" rockusb driver instead of the `rockusb` rs implementation.
* Cleaned up the async logging/state component. Error information should flow back via "FwUdateError".