### PR TITLE
auth: ask for `Basic` authentication scheme

### DIFF
--- a/src/authentication/authentication_context.rs
+++ b/src/authentication/authentication_context.rs
@@ -100,7 +100,9 @@ where
         let decoded = general_purpose::STANDARD.decode(credentials)?;
         let utf8 = std::str::from_utf8(&decoded)?;
         let Some((user, pass)) = utf8.split_once(':') else {
-            return Err(AuthenticationError::ParseError("basic authorization formatted wrong".to_string()));
+            return Err(AuthenticationError::ParseError(
+                "basic authorization formatted wrong".to_string(),
+            ));
         };
 
         self.validate_credentials(user, pass)

--- a/src/authentication/authentication_service.rs
+++ b/src/authentication/authentication_service.rs
@@ -166,11 +166,9 @@ fn unauthorized_response<B, E: ToString>(
     request: &HttpRequest,
     response_text: E,
 ) -> Result<ServiceResponse<EitherBody<B>>, Error> {
-    let bearer_str = format!(
-        "Basic realm=\"Access to Baseboard Management Controller\"",
-    );
+    let challenge = "Basic realm=\"Access to Baseboard Management Controller\"";
     let response = HttpResponse::Unauthorized()
-        .insert_header((header::WWW_AUTHENTICATE, bearer_str))
+        .insert_header((header::WWW_AUTHENTICATE, challenge))
         .body(response_text.to_string());
     Ok(ServiceResponse::map_into_right_body(ServiceResponse::new(
         request.clone(),

--- a/src/authentication/authentication_service.rs
+++ b/src/authentication/authentication_service.rs
@@ -167,8 +167,7 @@ fn unauthorized_response<B, E: ToString>(
     response_text: E,
 ) -> Result<ServiceResponse<EitherBody<B>>, Error> {
     let bearer_str = format!(
-        "Bearer error=invalid_token, error_description={}",
-        response_text.to_string()
+        "Basic realm=\"Access to Baseboard Management Controller\"",
     );
     let response = HttpResponse::Unauthorized()
         .insert_header((header::WWW_AUTHENTICATE, bearer_str))


### PR DESCRIPTION
This causes browsers to ask and use authentication credentials

Fixes turing-machines/BMC-Firmware#127