### PR TITLE
auth: format authorization denied based on scheme

### DIFF
--- a/src/authentication/authentication_context.rs
+++ b/src/authentication/authentication_context.rs
@@ -216,19 +216,23 @@ pub mod tests {
         );
 
         assert_eq!(
-            context.authorize_request("Bearer 1234").await.unwrap_err(),
+            context
+                .authorize_request("Bearer 1234")
+                .await
+                .unwrap_err()
+                .1,
             AuthenticationError::NoMatch("1234".to_string())
         );
 
         assert_eq!(
-            context.authorize_request("Bearer 2").await.unwrap_err(),
+            context.authorize_request("Bearer 2").await.unwrap_err().1,
             AuthenticationError::TokenExpired(twenty_sec_ago)
         );
 
         // After expired error, the token gets removed. Subsequent calls for that token will
         // therefore return "NoMatch"
         assert_eq!(
-            context.authorize_request("Bearer 2").await.unwrap_err(),
+            context.authorize_request("Bearer 2").await.unwrap_err().1,
             AuthenticationError::NoMatch("2".to_string())
         );
     }

--- a/src/authentication/authentication_errors.rs
+++ b/src/authentication/authentication_errors.rs
@@ -66,12 +66,14 @@ impl AuthenticationError {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub enum Scheme {
     Basic,
     Bearer,
 }
 
-pub struct SchemedAuthError(Option<Scheme>, AuthenticationError);
+#[derive(Debug, PartialEq)]
+pub struct SchemedAuthError(Option<Scheme>, pub AuthenticationError);
 
 impl SchemedAuthError {
     pub fn challenge(&self, realm: &str) -> String {

--- a/src/authentication/linux_authenticator.rs
+++ b/src/authentication/linux_authenticator.rs
@@ -36,10 +36,11 @@ type LinuxContext = AuthenticationContext<UnixValidator>;
 pub struct LinuxAuthenticator {
     context: Arc<LinuxContext>,
     authentication_path: &'static str,
+    realm: &'static str,
 }
 
 impl LinuxAuthenticator {
-    pub async fn new(authentication_path: &'static str) -> io::Result<Self> {
+    pub async fn new(authentication_path: &'static str, realm: &'static str) -> io::Result<Self> {
         let password_entries = Self::parse_shadow_file().await?;
         Ok(Self {
             context: Arc::new(LinuxContext::with_unix_validator(
@@ -47,6 +48,7 @@ impl LinuxAuthenticator {
                 Duration::from_secs(24 * 60 * 60),
             )),
             authentication_path,
+            realm,
         })
     }
 }
@@ -98,6 +100,7 @@ where
             Rc::new(service),
             self.context.clone(),
             self.authentication_path,
+            self.realm,
         )))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,13 @@ async fn main() -> anyhow::Result<()> {
 
     run_event_listener(bmc.clone().into_inner())?;
     let streaming_data_service = Data::new(StreamingDataService::new());
-    let authentication = Arc::new(LinuxAuthenticator::new("/api/bmc/authenticate").await?);
+    let authentication = Arc::new(
+        LinuxAuthenticator::new(
+            "/api/bmc/authenticate",
+            "Access to Baseboard Management Controller",
+        )
+        .await?,
+    );
 
     let run_server = HttpServer::new(move || {
         App::new()


### PR DESCRIPTION
When responding with an unauthorized response, make sure that the correct header is returned based on the scheme used.

Only a "realm" attribute is used when the scheme is unknown or not parse-able.