### PR TITLE
usbboot: move searching from `/dev/disk/by-id` to `/sys/block`

### DIFF
--- a/src/firmware_update/rpi_fwupdate.rs
+++ b/src/firmware_update/rpi_fwupdate.rs
@@ -34,7 +34,7 @@ pub async fn new_rpi_transport() -> Result<File, FwUpdateError> {
     sleep(Duration::from_secs(3)).await;
 
     log::info!("Checking for presence of a device file...");
-    let device_path = get_device_path(["RPi-MSD-"]).await?;
+    let device_path = get_device_path(&["RPi-MSD-"]).await?;
     let msd_device = tokio::fs::OpenOptions::new()
         .write(true)
         .read(true)

--- a/src/hal/stub/usbboot.rs
+++ b/src/hal/stub/usbboot.rs
@@ -36,8 +36,6 @@ pub(crate) fn extract_one_device<T>(devices: &[T]) -> Result<&T, FwUpdateError> 
     }
 }
 
-pub async fn get_device_path<I: IntoIterator<Item = &'static str>>(
-    allowed_vendors: I,
-) -> Result<PathBuf, FwUpdateError> {
+pub async fn get_device_path(_allowed_vendors: &[&str]) -> Result<PathBuf, FwUpdateError> {
     Ok(PathBuf::from("/tmp/stubbed"))
 }


### PR DESCRIPTION
After turing-machines/BMC-Firmware@1193ce32 mdev replaced eudev, and with it directory of symlinks /dev/disk/by-id stopped being generated. Work around this by searching in /sys/block instead.