### PR TITLE
streaming_data_service: improve error message

### DIFF
--- a/src/api/legacy.rs
+++ b/src/api/legacy.rs
@@ -512,7 +512,15 @@ async fn handle_file_upload(
 
     while let Some(Ok(chunk)) = field.next().await {
         if sender.send(chunk).await.is_err() {
-            return Err((StatusCode::GONE, "upload cancelled").into());
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ss.status()
+                    .await
+                    .error_message()
+                    .unwrap_or("transfer cancelled")
+                    .to_string(),
+            )
+                .into());
         }
     }
 

--- a/src/api/streaming_data_service.rs
+++ b/src/api/streaming_data_service.rs
@@ -227,6 +227,17 @@ pub enum StreamingState {
     Error(String),
 }
 
+impl StreamingState {
+    /// returns the error message when self == `StreamingState::Error(msg)`.
+    /// Otherwise returns `None`.
+    pub fn error_message(&self) -> Option<&str> {
+        if let StreamingState::Error(msg) = self {
+            return Some(msg);
+        }
+        None
+    }
+}
+
 impl Display for StreamingState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
When the channel closes which the sender uses to transport the file data. Ask the `StreamingDataService` what the current error state is rather then just responding to the client with a generic answer.