### PR TITLE
bmc_application: restore power and usb settings

### DIFF
--- a/src/api/streaming_data_service.rs
+++ b/src/api/streaming_data_service.rs
@@ -59,7 +59,7 @@ impl StreamingDataService {
         let (written_sender, written_receiver) = watch::channel(0u64);
         let cancel = CancellationToken::new();
         let (sender, worker) = action
-            .into_data_processor(64, written_sender, cancel.child_token())
+            .into_data_processor(256, written_sender, cancel.child_token())
             .await?;
         let context =
             TransferContext::new(id, process_name, size, written_receiver, sender, cancel);

--- a/src/app/bmc_application.rs
+++ b/src/app/bmc_application.rs
@@ -117,9 +117,10 @@ impl BmcApplication {
 
     pub async fn initialize_power(&self) -> anyhow::Result<()> {
         if self.app_db.get::<u8>(ACTIVATED_NODES_KEY).await != 0 {
-            self.power_on().await?;
+            self.power_on().await
+        } else {
+            self.power_off().await
         }
-        Ok(())
     }
 
     async fn initialize_usb_mode(&self) -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,6 @@ fn init_logger() {
 
     simple_logger::SimpleLogger::new()
         .with_level(level)
-        .with_module_level("bmcd", LevelFilter::Info)
         .with_module_level("actix_http", LevelFilter::Info)
         .with_module_level("h2", LevelFilter::Info)
         .with_colors(true)


### PR DESCRIPTION
This commit contains 2 improvements:
* Internal operations are not triggering persistency updates anymore. Minimizing flash wear.
* After a flash command the power and USB settings are restored to their previous values