### PR TITLE
api: add `node_info` set & get endpoints

### DIFF
--- a/src/hal.rs
+++ b/src/hal.rs
@@ -13,7 +13,7 @@ use std::fmt::Display;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-mod helpers;
+pub mod helpers;
 
 macro_rules! conditional_import {
     ($attribute_condition:meta, $($statement:item)+) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,8 +15,10 @@ mod event_listener;
 mod io;
 
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::bail;
+
 #[doc(inline)]
 pub use event_listener::*;
 pub use io::*;
@@ -104,4 +106,12 @@ pub async fn get_device_path(allowed_vendors: &[&str]) -> anyhow::Result<PathBuf
     };
 
     Ok(tokio::fs::canonicalize(format!("/dev/{}", name)).await?)
+}
+
+/// Get current time in seconds since Unix epoch. Returns `None` if current time is before epoch.
+pub fn get_timestamp_unix() -> Option<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|x| x.as_secs())
 }


### PR DESCRIPTION
For testing, use

    curl 'https://turingpi.local/api/bmc?opt=set&type=node_info' \
        -X POST \
        -H "Content-Type: application/json" \
        -d '
        {
            "node_info":
            [
                {
                    "node": 1,
                    "module_name": "Raspberry Pi CM4",
                    "uart_baud": 115200
                },
                {
                    "node": 3,
                    "name": "New Name"
                }
            ]
        }' \
        -k \
        --header "Authorization: Bearer $token"

Closes #77