### PR TITLE
open port 80+443 on ipv6 too

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> anyhow::Result<()> {
             .service(Files::new("/", &config.www).index_file("index.html"))
     })
     .bind_openssl(("0.0.0.0", config.port), tls)?
-    .bind_openssl(("::1", config.port), tls6)?
+    .bind_openssl(("::", config.port), tls6)?
     .keep_alive(KeepAlive::Os)
     .workers(2)
     .run();
@@ -100,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
                     .default_service(web::route().to(redirect))
             })
             .bind(("0.0.0.0", HTTP_PORT))?
-            .bind(("::1", HTTP_PORT))?
+            .bind(("::", HTTP_PORT))?
             .run(),
         );
     }


### PR DESCRIPTION
This issue is fixed in v2: https://github.com/turing-machines/BMC-Firmware/issues/79
But please open port 80 and 443 on IPv6 too, so that its fully working on IPv6 only networks.