### PR TITLE
feat: add API support for cooling devices

### DIFF
--- a/src/api/legacy.rs
+++ b/src/api/legacy.rs
@@ -38,6 +38,7 @@ use async_compression::Level;
 use humansize::{format_size, DECIMAL};
 use serde_json::json;
 use std::collections::HashMap;
+use std::ffi::c_ulong;
 use std::io;
 use std::ops::Deref;
 use std::path::PathBuf;
@@ -521,7 +522,7 @@ async fn set_cooling_info(query: Query) -> LegacyResult<()> {
         .ok_or(LegacyResponse::bad_request("Device not found"))?;
 
     // check if the speed is a valid number within the range of the device
-    let speed = match u8::from_str(speed_str) {
+    let speed = match c_ulong::from_str(speed_str) {
         Ok(s) if s <= device.max_speed => s,
         _ => return Err(LegacyResponse::bad_request(format!("Parameter `speed` must be a number between 0-{}", device.max_speed))),
     };

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,3 +17,4 @@ pub mod event_application;
 pub mod transfer_action;
 pub mod upgrade_worker;
 pub mod usb_gadget;
+pub mod cooling_device;

--- a/src/app/cooling_device.rs
+++ b/src/app/cooling_device.rs
@@ -1,0 +1,70 @@
+// Copyright 2023 Turing Machines
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct CoolingDevice {
+    pub device: String,
+    pub speed: u8,
+    pub max_speed: u8,
+}
+
+pub async fn get_cooling_state() -> Vec<CoolingDevice> {
+    let mut result = Vec::new();
+
+    if let Ok(mut dir) = tokio::fs::read_dir("/sys/class/thermal").await {
+        while let Some(device) = dir.next_entry().await.unwrap_or(None) {
+            let device_name = device.file_name().to_string_lossy().into_owned();
+            let device_path = device.path();
+
+            let cur_state_path = device_path.join("cur_state");
+            let max_state_path = device_path.join("max_state");
+
+            let cur_state = match tokio::fs::read_to_string(cur_state_path).await {
+                Ok(state) => state.trim().parse::<u8>().unwrap_or(0),
+                Err(err) => {
+                    eprintln!("Error reading cur_state file: {}", err);
+                    0
+                }
+            };
+
+            let max_state = match tokio::fs::read_to_string(max_state_path).await {
+                Ok(max_speed) => max_speed.trim().parse::<u8>().unwrap_or(0),
+                Err(err) => {
+                    eprintln!("Error reading max_state file: {}", err);
+                    0
+                }
+            };
+
+            result.push(CoolingDevice {
+                device: device_name,
+                speed: cur_state,
+                max_speed: max_state,
+            });
+        }
+    }
+
+    result
+}
+
+pub async fn set_cooling_state(device: &str, speed: &u8) -> anyhow::Result<()> {
+    let device_path = Path::new("/sys/class/thermal").join(device).join("cur_state");
+
+    tokio::fs::write(device_path, speed.to_string()).await?;
+
+    Ok(())
+}

--- a/src/app/cooling_device.rs
+++ b/src/app/cooling_device.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
+use std::{ffi::c_ulong, path::Path};
 
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
 pub struct CoolingDevice {
     pub device: String,
-    pub speed: u8,
-    pub max_speed: u8,
+    pub speed: c_ulong,
+    pub max_speed: c_ulong,
 }
 
 pub async fn get_cooling_state() -> Vec<CoolingDevice> {
@@ -39,7 +39,7 @@ pub async fn get_cooling_state() -> Vec<CoolingDevice> {
             let max_state_path = device_path.join("max_state");
 
             let cur_state = match tokio::fs::read_to_string(cur_state_path).await {
-                Ok(state) => state.trim().parse::<u8>().unwrap_or(0),
+                Ok(state) => state.trim().parse::<c_ulong>().unwrap_or(0),
                 Err(err) => {
                     eprintln!("Error reading cur_state file: {}", err);
                     0
@@ -47,7 +47,7 @@ pub async fn get_cooling_state() -> Vec<CoolingDevice> {
             };
 
             let max_state = match tokio::fs::read_to_string(max_state_path).await {
-                Ok(max_speed) => max_speed.trim().parse::<u8>().unwrap_or(0),
+                Ok(max_speed) => max_speed.trim().parse::<c_ulong>().unwrap_or(0),
                 Err(err) => {
                     eprintln!("Error reading max_state file: {}", err);
                     0
@@ -65,7 +65,7 @@ pub async fn get_cooling_state() -> Vec<CoolingDevice> {
     result
 }
 
-pub async fn set_cooling_state(device: &str, speed: &u8) -> anyhow::Result<()> {
+pub async fn set_cooling_state(device: &str, speed: &c_ulong) -> anyhow::Result<()> {
     let device_path = Path::new("/sys/class/thermal").join(device).join("cur_state");
 
     tokio::fs::write(device_path, speed.to_string()).await?;

--- a/src/app/cooling_device.rs
+++ b/src/app/cooling_device.rs
@@ -29,6 +29,10 @@ pub async fn get_cooling_state() -> Vec<CoolingDevice> {
     if let Ok(mut dir) = tokio::fs::read_dir("/sys/class/thermal").await {
         while let Some(device) = dir.next_entry().await.unwrap_or(None) {
             let device_name = device.file_name().to_string_lossy().into_owned();
+            if !device_name.starts_with("cooling_device") {
+                continue;
+            }
+
             let device_path = device.path();
 
             let cur_state_path = device_path.join("cur_state");


### PR DESCRIPTION
Adds logic around the `/sys/class/thermal` devices, listing all found records as a JSON array for `get_cooling_state` and `set_cooling_state` to set a new speed for a specific device.


The two added endpoints and their respective responses are:
```
https://turingpi.local/api/bmc?opt=get&type=cooling

{
  "response": [
    {
      "result": [
        {
          "device": "cooling_device0",
          "max_speed": 10,
          "speed": 0
        }
      ]
    }
  ]
}
```
```
https://turingpi.local/api/bmc?opt=set&type=cooling&device=cooling_device0&speed=5

{
  "response": [
    {
      "result": "ok"
    }
  ]
}
```

I built a working firmware [here](https://github.com/barrenechea/BMC-Firmware/actions/runs/8591403659) to get that output from my own v2.4 board.

The logic I wrote technically supports more than one fan if the hardware allows it. I expect this to be limited to a single fan for v2.4 boards, but it opens the door for future multi-fan hardware.

If I'm not mistaken, the logic for `get_cooling_state` should return an empty array if the board has not soldered the EMC2301 fan controller. It would be nice if this were validated.