### PR TITLE
Allow binding to a configurable address.

### DIFF
--- a/default_config.yaml
+++ b/default_config.yaml
@@ -1,6 +1,6 @@
 ---
 # The TCP port which the daemon listens on.
-host: 0.0.0.0
+host: "::"
 port: 443
 # Directory to www pages. Can be changed in order to host a custom website.
 www: /srv/bmcd/www/

--- a/default_config.yaml
+++ b/default_config.yaml
@@ -1,5 +1,6 @@
 ---
 # The TCP port which the daemon listens on.
+host: 0.0.0.0
 port: 443
 # Directory to www pages. Can be changed in order to host a custom website.
 www: /srv/bmcd/www/

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
             // Serve a static tree of files of the web UI. Must be the last item.
             .service(Files::new("/", &config.www).index_file("index.html"))
     })
-    .bind_openssl(("::", config.port), tls)?
+    .bind_openssl((config.host, config.port), tls)?
     .keep_alive(KeepAlive::Os)
     .workers(2)
     .run();
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
                     .configure(info_config)
                     .default_service(web::route().to(redirect))
             })
-            .bind(("::", HTTP_PORT))?
+            .bind((config.host, HTTP_PORT))?
             .run(),
         );
     }


### PR DESCRIPTION
Since the local `tpi` utility appears to rely on the `bmcd`, it can't be disabled, but I'm racking up a TuringPi2 at the datacenter shortly, so the BMC will have a public IP address and I would like to avoid exposing the HTTP server to the world.