### PR TITLE
Removes Basic Auth for static files, enables SpA route handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -85,9 +85,9 @@ async fn main() -> anyhow::Result<()> {
 
     let run_server = HttpServer::new(move || {
         App::new()
-            .wrap(authentication.clone())
             .service(
                 web::scope("/api/bmc")
+                    .wrap(authentication.clone())
                     .app_data(bmc.clone())
                     .app_data(streaming_data_service.clone())
                     .app_data(serial_service.clone())


### PR DESCRIPTION
The changes are:
- Removed Basic Auth for static files, allowing the SpA to handle authentication & routes protection. Addressed by fce2d93d01a3b452e9cab2b1f8bc192aab6fb6c0

- Allow SpA to resolve routes. cfaae9c9988f35a7d083809effde5c4140cc0a8a

Aims to provide support for https://github.com/turing-machines/BMC-UI/pull/5