### PR TITLE
Sanitize termination characters from file read, split model data

### DIFF
--- a/src/app/bmc_info.rs
+++ b/src/app/bmc_info.rs
@@ -63,6 +63,8 @@ pub async fn get_mac_address(interface: &str) -> String {
     tokio::fs::read_to_string(format!("/sys/class/net/{}/address", interface))
         .await
         .unwrap_or("Unknown".to_owned())
+        .trim_end_matches(|c| c == '\0' || c == '\n')
+        .to_string()
 }
 
 pub fn get_fs_stat(device: &str) -> anyhow::Result<(u64, u64)> {


### PR DESCRIPTION
I'm bringing some sanitization into strings coming from file reads.

For the `hostname` and `mac` fields, they were coming with `\n` at the end, and for the new `model` field, it was coming with `\0` (weirdly handled once parsed as JSON):

```
GET https://turingpi.local/api/bmc?opt=get&type=about
{
    "response": [
        {
            "result": {
                ...
                "hostname": "turingpi\n",              <- newline
                "model": "Turing Pi 2 (v2.4)\u0000",   <- null char
            }
        }
    ]
}

GET https://turingpi.local/api/bmc?opt=get&type=info
{
    "response": [
        {
            "result": {
                "ip": [
                    {
                        ...
                        "mac": "02:00:16:4e:70:e4\n"   <- newline
                    }
                ],
                ...
            }
        }
    ]
}
```

I'm generally applying `.trim_end_matches(|c| c == '\0' || c == '\n')` to do the cleanup from file reads.

Also, I've modified the `model` prop to be returned as `board_model` and `board_revision`. That way, I can cleanly perform semantic versioning comparisons against the incoming `board_revision` over the frontend side, making a much cleaner integration. I decoupled it similarly to what `read_hostname` does.

The outputs have been validated to arrive clean now:
```
{
    "response": [
        {
            "result": {
                ...
                "board_model": "Turing Pi 2",   <- new prop
                "board_revision": "2.4",        <- new prop
                "hostname": "turingpi",         <- no newline
            }
        }
    ]
}

{
                        ...
                        "mac": "02:00:16:4e:70:e4"
                        ...
}
```

Confirmed to work with build: https://github.com/barrenechea/BMC-Firmware/actions/runs/9177111047